### PR TITLE
Fix missing spaces between key and value

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -894,12 +894,12 @@ layers:
                 grid:
                     color: *water1
         playas-early:
-            filter: { kind: playa, $zoom: {max:6} }
+            filter: { kind: playa, $zoom: {max: 6} }
             draw:
                 ground:
                     visible: false
         playas:
-            filter: { kind: playa, $zoom: {min:6} }
+            filter: { kind: playa, $zoom: {min: 6} }
             draw:
                 polygons:
                     color: [0.870,0.870,0.870]


### PR DESCRIPTION
The YAML spec requires key-value pairs to be separated with a colon and a space (except for JSON-like mappings with quotes). Some parsers and validators seem to tolerate a missing space, but it is invalid to the parser in tangram-es.
