### PR TITLE
only inject dot methods for fragment shader

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -676,9 +676,11 @@ styles:
                     //
                     // Get the coordinates in tile space
                     // ================================
-                    vec2 getTileCoords () {
-                        return fract(v_pos.xy*TILE_SCALE);
-                    }
+                    #ifdef TANGRAM_FRAGMENT_SHADER
+                        vec2 getTileCoords () {
+                            return fract(v_pos.xy*TILE_SCALE);
+                        }
+                    #endif
 
                 position: |
                     // Normalize the attribute position of a vertex
@@ -729,23 +731,25 @@ styles:
         shaders:
             blocks:
                 global: |
-                    float TileDots(float scale, float size) {
-                        vec2 IN = brick(getTileCoords()*scale,2.);
-                        float A = circleDF(vec2(0.5)-IN)*1.8;
-                        float d = 0.0;
-                        if (u_map_position.z < 18.) {
-                            vec2 OUT = fract(getTileCoords()*scale*2.);
-                            float B = circleDF(vec2(0.25)-OUT)*7.;
-                            B = min(B, circleDF(vec2(0.75,0.25)-OUT)*7.);
-                            B = min(B, circleDF(vec2(0.5,0.75)-OUT)*7.);
-                            B = min(B, circleDF(vec2(0.,0.75)-OUT)*7.);
-                            B = min(B, circleDF(vec2(1.,0.75)-OUT)*7.);
-                            d = mix(A, B, pow(fract(u_map_position.z),10.));
-                        } else {
-                            d = A;
+                    #ifdef TANGRAM_FRAGMENT_SHADER
+                        float TileDots(float scale, float size) {
+                            vec2 IN = brick(getTileCoords()*scale,2.);
+                            float A = circleDF(vec2(0.5)-IN)*1.8;
+                            float d = 0.0;
+                            if (u_map_position.z < 18.) {
+                                vec2 OUT = fract(getTileCoords()*scale*2.);
+                                float B = circleDF(vec2(0.25)-OUT)*7.;
+                                B = min(B, circleDF(vec2(0.75,0.25)-OUT)*7.);
+                                B = min(B, circleDF(vec2(0.5,0.75)-OUT)*7.);
+                                B = min(B, circleDF(vec2(0.,0.75)-OUT)*7.);
+                                B = min(B, circleDF(vec2(1.,0.75)-OUT)*7.);
+                                d = mix(A, B, pow(fract(u_map_position.z),10.));
+                            } else {
+                                d = A;
+                            }
+                            return aastep(size,d);
                         }
-                        return aastep(size,d);
-                    }
+                    #endif
 
     dots2:
         mix: pattern-dots


### PR DESCRIPTION
Fixes: https://github.com/tangrams/tangram-es/issues/358

Should we have specific injection points for global-fragment or global-vertex?
Or maybe some other approach, to make things more intuitive and simpler for a user?
