### PR TITLE
Convert tile-based shaders to use modelPosition() accessor

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -478,12 +478,12 @@ styles:
                 global: |
                     // GridTile
                     //=============================
-                    varying vec3 v_pos;
+                    varying vec2 v_pos;
 
                     #ifdef TANGRAM_FRAGMENT_SHADER
 
                     vec2 TileCoords() {
-                        return fract(v_pos.xy*0.0002445);
+                        return v_pos;
                     }
 
                     bool grid(vec2 st, float res, float press) {
@@ -603,7 +603,7 @@ styles:
                     #endif
                 position: |
                     // GridTile
-                    v_pos = a_position.xyz * 32767.;
+                    v_pos = modelPosition().xy;
 
     grid:
         base: polygons
@@ -673,25 +673,22 @@ styles:
                     color.rgb = mix(BACKGROUND, color.rgb,TileDotsDF(35.,.21));
     space-tile:
         shaders:
-            defines:
-                TILE_SCALE: 0.0002445
-                NORMALIZED_SHORT(x): (x * 32767.)
             blocks:
                 global: |
                     // Variant to be add to both vertex and fragments shaders
-                    varying vec3 v_pos;
+                    varying vec2 v_pos;
                     //
                     // Get the coordinates in tile space
                     // ================================
                     #ifdef TANGRAM_FRAGMENT_SHADER
                         vec2 getTileCoords () {
-                            return fract(v_pos.xy*TILE_SCALE);
+                            return v_pos;
                         }
                     #endif
 
                 position: |
-                    // Normalize the attribute position of a vertex
-                    v_pos = NORMALIZED_SHORT(a_position.xyz);
+                    // Send tile position to fragment shader
+                    v_pos = modelPosition().xy;
     tools-aastep:
         shaders:
             extensions: OES_standard_derivatives
@@ -2216,7 +2213,7 @@ layers:
                         transform: uppercase
 
         country-z2:
-            filter: 
+            filter:
                 all:
                     - kind: [country]
                     - $zoom: [2]

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     <script src="lib/keymaster.js"></script>
 
     <!-- Main tangram library -->
-    <script src="https://mapzen.com/tangram/0.3/tangram.min.js"></script>
+    <script src="https://mapzen.com/tangram/0.4/tangram.min.js"></script>
 
     <!-- Demo module -->
     <script src="main.js"></script>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         /*width: 200px;*/
         /*margin-left: -100px;*/
         position: absolute;
-        z-index: 10;
+        z-index: 1000;
         text-align: left;
         margin: 0px;
         background: #E1E1E1;

--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ map = (function () {
         selection_info.style.display = 'block';
 
         // Show selected feature on hover
-        scene.container.addEventListener('mousemove', function (event) {
+        map.getContainer().addEventListener('mousemove', function (event) {
             var pixel = { x: event.clientX, y: event.clientY };
 
             scene.getFeatureAt(pixel).then(function(selection) {
@@ -99,7 +99,7 @@ map = (function () {
                         selection_info.style.left = (pixel.x + 5) + 'px';
                         selection_info.style.top = (pixel.y + 15) + 'px';
                         selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
-                        scene.container.appendChild(selection_info);
+                        map.getContainer().appendChild(selection_info);
                     }
                     else if (selection_info.parentNode != null) {
                         selection_info.parentNode.removeChild(selection_info);
@@ -119,7 +119,7 @@ map = (function () {
         });
         
         // Show selected feature on hover
-        scene.container.addEventListener('click', function (event) {
+        map.getContainer().addEventListener('click', function (event) {
             var pixel = { x: event.clientX, y: event.clientY };
 
 			scene.getFeatureAt(pixel).then(function(selection) {    
@@ -144,7 +144,7 @@ map = (function () {
 						selection_info.style.left = (pixel.x + 5) + 'px';
 						selection_info.style.top = (pixel.y + 15) + 'px';
 						selection_info.innerHTML = '<span class="labelInner">' + label + '</span>';
-						scene.container.appendChild(selection_info);
+						map.getContainer().appendChild(selection_info);
 					}
 					else if (selection_info.parentNode != null) {
 						selection_info.parentNode.removeChild(selection_info);


### PR DESCRIPTION
Compatibility with JS (once Tangram 0.4.0 is released) and ES (since they pack vertex position values slightly differently right now... and these are low-level values where we want to keep the implementation opaque anyway).
