### PR TITLE
Fix: undefined behavior for region rule match

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -2604,12 +2604,12 @@ layers:
                         fill: [0.4,0.4,0.4]
 
         region:
-            filter: { name: true, kind: [state], $zoom: {min: 6, max: 9} }
+            filter: { name: true, kind: [state], $zoom: {min: 7, max: 9} }
             draw:
                 text:
                     priority: 2
                     visible: *text_visible_admin
-                    text_source: function() { if(feature["name:short"]) { return feature["name"]; } else { return "" } }
+                    text_source: function() { if(feature["name:short"]) { return feature["name"]; } else { return ""; } }
                     font:
                         size: 14px
                         weight: 200
@@ -2621,12 +2621,12 @@ layers:
     #                interactive: true
     #                sprite: *townspot_sprite
             pesky:
-                filter: { name: ["Western Cape","Eastern Cape","Northern Cape","North West","Limpopo","KwaZulu-Natal","Hamburg","Freie und Hansestadt Hamburg","Neuchâtel","Nordrhein-Westfalen","Haute-Normandie","Baden-Württemberg","Bayern","Sachsen-Anhalt","Berlin","Mecklenburg-Vorpommern","Schleswig-Holstein","Brandenburg","Niedersachsen","Saarland","Thüringen","Hessen","Sachsen"], $zoom: {min: 6, max: 8} }
+                filter: { name: ["Western Cape","Eastern Cape","Northern Cape","North West","Limpopo","KwaZulu-Natal","Hamburg","Freie und Hansestadt Hamburg","Neuchâtel","Nordrhein-Westfalen","Haute-Normandie","Baden-Württemberg","Bayern","Sachsen-Anhalt","Berlin","Mecklenburg-Vorpommern","Schleswig-Holstein","Brandenburg","Niedersachsen","Saarland","Thüringen","Hessen","Sachsen"], $zoom: {min: 7, max: 8} }
                 draw:
                     text:
                         visible: false
             small-ones:
-                filter: { name: ["Delaware","New Jersey","Connecticut","Rhode Island","Massachusetts","New Hampshire","Vermont"], $zoom: {min: 6, max: 8} }
+                filter: { name: ["Delaware","New Jersey","Connecticut","Rhode Island","Massachusetts","New Hampshire","Vermont"], $zoom: {min: 7, max: 8} }
                 draw:
                     text:
                         text_source: function() { return feature["name:abbreviation"] || feature["name"]; }


### PR DESCRIPTION
Similar to https://github.com/tangrams/eraser-map/issues/101, this fixes an issue with parallel rule matching for region
names.

NOTE: I am not sure what should be styling behavior here with respect to design point of you, so please feel free to
change it to reflect better design.

cc. @nvkelso 
