### PR TITLE
Adjust text anchors & offsets so labels are below icons

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -2473,7 +2473,6 @@ layers:
         draw:
             text:
                 visible: false    # labels are enabled by each layer below
-                anchor: bottom
                 font:
                     family: *text_font_family
                     # weight: 500
@@ -2690,6 +2689,7 @@ layers:
                 icons:
                     priority: 5
                 text:
+                    anchor: bottom
                     priority: 6
 
             populated-places-natural-earth-z2:
@@ -2698,7 +2698,7 @@ layers:
                     text:
                         interactive: true
                         visible: *text_visible_populated_places
-                        offset: [0, 3.5px] # half icon size
+                        offset: [0, 1px] # half icon size
                         font:
                             size: 10px
                             fill: *text_fill
@@ -2716,7 +2716,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 3.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 11px
                                 fill: *text_fill
@@ -2731,7 +2731,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 3.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 9px
                                 fill: *text_fill
@@ -2749,7 +2749,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 13px
                                 fill: *text_fill
@@ -2765,7 +2765,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 10px
                                 fill: *text_fill
@@ -2783,7 +2783,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 6.5px] # half icon size
+                            offset: [0, 3px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -2805,7 +2805,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -2833,7 +2833,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 9px
@@ -2864,7 +2864,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 6.5px] # half icon size
+                            offset: [0, 3px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 15px
@@ -2887,7 +2887,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 12px
@@ -2916,7 +2916,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 10px
@@ -2947,7 +2947,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 16px
@@ -2970,7 +2970,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 13px
@@ -2999,7 +2999,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3039,7 +3039,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3062,7 +3062,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3092,7 +3092,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3123,7 +3123,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.30,0.30,0.30]
                                 size: 8px
@@ -3155,7 +3155,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3177,7 +3177,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3205,7 +3205,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3244,7 +3244,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 17px
                         icons:
@@ -3268,7 +3268,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3298,7 +3298,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3329,7 +3329,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.30,0.30,0.30]
                                 size: 9px
@@ -3361,7 +3361,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3383,7 +3383,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3411,7 +3411,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3450,7 +3450,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 17px
                         icons:
@@ -3466,7 +3466,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3482,7 +3482,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3499,7 +3499,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 fill: [0.35,0.35,0.35]
                                 size: 9px
@@ -3517,7 +3517,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
+                            offset: [0, 2px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3539,7 +3539,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3567,7 +3567,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
+                            offset: [0, 1px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3598,7 +3598,10 @@ layers:
                         - not: { kind: [country, county, state, island, neighbourhood, suburb, quarter] }
                         - $zoom: [11]
                         - kind: [city,town]
-
+                draw:
+                    text:
+                        anchor: center
+                        
                 z11places-1:
                     filter:
                         any:
@@ -3636,14 +3639,17 @@ layers:
 
             populated-places-natural-earth-z11-backfill:
                 filter: { name: true, source: naturalearthdata.com, $zoom: [11], population: { max: 10000 } }
-                draw: { text: { font: { fill: *text_fill } } }
+                draw:
+                    text:
+                        anchor: center
+                        font:
+                            fill: *text_fill
                 z11places-1-ne:
                     filter: { scalerank: [0,1] }
                     draw:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3665,7 +3671,6 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3693,7 +3698,6 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3724,6 +3728,9 @@ layers:
                         - not: { kind: [country, county, state, island, neighbourhood, suburb, quarter] }
                         - $zoom: [12]
                         - kind: [city,town]
+                draw:
+                    text:
+                        anchor: center
 
                 z12places-1:
                     filter:
@@ -3761,14 +3768,18 @@ layers:
 
             populated-places-natural-earth-z12-backfill:
                 filter: { name: true, source: naturalearthdata.com, $zoom: [12], population: { max: 7000 } }
-                draw: { text: { font: { fill: *text_fill } } }
+                draw:
+                    text:
+                        anchor: center
+                        font:
+                            fill: *text_fill
+
                 z12places-1-ne:
                     filter: { scalerank: [0,1] }
                     draw:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3790,7 +3801,6 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3818,7 +3828,6 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
-                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3839,6 +3848,93 @@ layers:
                             text:
                                 font:
                                     size: 12px
+
+            populated-places-osm-z13-z14:
+                filter:
+                    all:
+                        - source: openstreetmap
+                        - name: true
+                        - population: true
+                        - not: { kind: [country, county, state, island, neighbourhood, suburb, quarter] }
+                        - $zoom: [13,14]
+                        - kind: [city,town]
+                draw:
+                    text:
+                        anchor: center
+                        font:
+                            weight: 600
+                            fill: *text_fill
+                z14:
+                    filter: 
+                        $zoom: [14]
+                    draw:
+                        text:
+                            font:
+                                weight: 600
+
+                z13places-1:
+                    filter:
+                        any:
+                            - { population: { min: 200000 } }
+                    draw:
+                        text:
+                            visible: false
+
+                z13places-2:
+                    filter:
+                        any:
+                            - { population: { min: 50000, max: 199999 } }
+                    draw:
+                        text:
+                            interactive: true
+                            visible: *text_visible_populated_places
+                            font:
+                                size: 14px
+
+                z13places-3:
+                    filter:
+                        any:
+                        - { population: { min: 7000, max: 49999 } }
+                    draw:
+                        text:
+                            interactive: true
+                            visible: *text_visible_populated_places
+                            font:
+                                size: 12px
+
+            populated-places-natural-earth-z13-z14-backfill:
+                filter: { name: true, source: naturalearthdata.com, $zoom: [13,14], population: { max: 7000 } }
+                draw:
+                    text:
+                        anchor: center
+                        font:
+                            fill: *text_fill
+                            weight: 400
+                            fill: *text_fill
+
+                z13places-1-ne:
+                    filter: { scalerank: [0,1] }
+                    draw:
+                        text:
+                            visible: false
+
+                z13places-2-ne:
+                    filter: { scalerank: [2,3,4,5] }
+                    draw:
+                        text:
+                            interactive: true
+                            visible: *text_visible_populated_places
+                            font:
+                                size: 13px
+
+                z13places-3-ne:
+                    filter: { scalerank: [6,7,8,9,10,11,12] }
+                    draw:
+                        text:
+                            interactive: true
+                            visible: *text_visible_populated_places
+                            font:
+                                size: 12px
 
             # populated-places-osm:
             #     filter: { name: true, source: openstreetmap, not: { kind: [country, county, state, island, neighbourhood, suburb, quarter] }, $zoom: {min: 12} }
@@ -5158,7 +5254,7 @@ layers:
                     dots2:
                         color: [[4,[0.655,0.800,0.796]],[8,[0.588,0.780,0.773]]]
                         # todo: what is this?
-                        order: 0
+                        order: 1
                         visible: true
                 us_national_park:
                     # yosemite national park, death valley national park, grand canyon national park

--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -4015,8 +4015,9 @@ layers:
                 priority: 10
             text:
                 visible: false    # labels are enabled by each layer below
-                move_into_tile: false
-                offset: [[13,13px],[14,15px],[16,19px]]
+                move_into_tile: false # preserves text alignment w/icons in JS
+                anchor: bottom
+                offset: [[13, [0, 6px]], [16, [0, 8px]], [19, [0, 10px]]] # offset tracks alongside icon size (half icon height)
                 interactive: true
                 priority: 11
                 font:

--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -4163,7 +4163,6 @@ layers:
                         text:
                             visible: *text_visible_poi_landuse
                             interactive: true
-                            offset: [0, 14px]
                             font:
                                 fill: [0.200,0.409,0.398] #*text_fill_park
                                 size: 13px
@@ -4219,7 +4218,6 @@ layers:
                         text:
                             visible: *text_visible_landuse_green
                             interactive: true
-                            offset: [0, 14px]
                             font:
                                 fill: [0.181,0.370,0.361]
                                 size: 12px

--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -2473,6 +2473,7 @@ layers:
         draw:
             text:
                 visible: false    # labels are enabled by each layer below
+                anchor: bottom
                 font:
                     family: *text_font_family
                     # weight: 500
@@ -2689,7 +2690,6 @@ layers:
                 icons:
                     priority: 5
                 text:
-                    offset: [0, 8px]
                     priority: 6
 
             populated-places-natural-earth-z2:
@@ -2698,6 +2698,7 @@ layers:
                     text:
                         interactive: true
                         visible: *text_visible_populated_places
+                        offset: [0, 3.5px] # half icon size
                         font:
                             size: 10px
                             fill: *text_fill
@@ -2715,6 +2716,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 3.5px] # half icon size
                             font:
                                 size: 11px
                                 fill: *text_fill
@@ -2729,6 +2731,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 3.5px] # half icon size
                             font:
                                 size: 9px
                                 fill: *text_fill
@@ -2746,6 +2749,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 13px
                                 fill: *text_fill
@@ -2761,6 +2765,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 10px
                                 fill: *text_fill
@@ -2778,6 +2783,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 6.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -2799,6 +2805,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -2826,6 +2833,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 9px
@@ -2856,6 +2864,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 6.5px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 15px
@@ -2878,6 +2887,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 12px
@@ -2906,6 +2916,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 10px
@@ -2936,6 +2947,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 16px
@@ -2958,6 +2970,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 fill: *text_fill
                                 size: 13px
@@ -2986,6 +2999,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3025,6 +3039,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3047,6 +3062,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3076,6 +3092,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3106,6 +3123,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4px] # half icon size
                             font:
                                 fill: [0.30,0.30,0.30]
                                 size: 8px
@@ -3137,6 +3155,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3158,6 +3177,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3185,6 +3205,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3223,6 +3244,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 17px
                         icons:
@@ -3246,6 +3268,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3275,6 +3298,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3305,6 +3329,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4px] # half icon size
                             font:
                                 fill: [0.30,0.30,0.30]
                                 size: 9px
@@ -3336,6 +3361,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3357,6 +3383,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3384,6 +3411,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3422,6 +3450,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 17px
                         icons:
@@ -3437,6 +3466,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3452,6 +3482,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 fill: [0.25,0.25,0.25]
                                 size: 11px
@@ -3468,6 +3499,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4px] # half icon size
                             font:
                                 fill: [0.35,0.35,0.35]
                                 size: 9px
@@ -3485,6 +3517,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3506,6 +3539,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3533,6 +3567,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3608,6 +3643,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3629,6 +3665,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3656,6 +3693,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3669,7 +3707,7 @@ layers:
                                 font:
                                     size: 14px
                             icons:
-                                    sprite: capital-s
+                                sprite: capital-s
                     state_capital:
                         filter: { state_capital: yes }
                         draw:
@@ -3730,6 +3768,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 7px] # half icon size
                             font:
                                 size: 16px
                         icons:
@@ -3751,6 +3790,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 5.5px] # half icon size
                             font:
                                 size: 13px
                         icons:
@@ -3778,6 +3818,7 @@ layers:
                         text:
                             interactive: true
                             visible: *text_visible_populated_places
+                            offset: [0, 4.5px] # half icon size
                             font:
                                 size: 11px
                         icons:
@@ -3791,7 +3832,7 @@ layers:
                                 font:
                                     size: 14px
                             icons:
-                                    sprite: capital-s
+                                sprite: capital-s
                     state_capital:
                         filter: { state_capital: yes }
                         draw:

--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -4435,7 +4435,14 @@ layers:
             station-train-subway:
                 filter: { kind: [station, train-station, train_station], $zoom: { min: 11 } }
                 visible: *label_visible_station
-                draw:   { icons: { visible: *icon_visible_station, sprite: train-station, size: [[13,12px],[14,14px],[15,16px],[17,20px]] }, text: { visible: *text_visible_station } }
+                draw:
+                    icons:
+                        visible: *icon_visible_station
+                        sprite: train-station
+                        size: [[13, 12px], [14, 14px], [15, 16px], [17, 20px]]
+                    text:
+                        visible: *text_visible_station
+                        offset: [[13, [0, 6px]], [14, [0, 7px]],[15, [0, 8px]], [17, [0, 10px]]]
                 low-priority-early:
                     filter: { kind_tile_rank: { min: 5 }, area: false, $zoom: { min: 0, max: 14 } }
                     draw:
@@ -4465,6 +4472,8 @@ layers:
                 draw:
                     icons:
                         size: [[13, 12px], [16, 18px]]
+                    text:
+                        offset: [[13, [0, 6px]], [16, [0, 9px]]]
             bus-stop-bus-station-labels:
                 filter:
                     kind: [bus_stop, bus_station]
@@ -4482,12 +4491,11 @@ layers:
                         kind: [bus_stop]
                         $zoom: { max: 19 }
                     draw:
-                        text:
-                            visible: false
                         icons:
                             size: [[13, 8px], [19, 18px]]
+                        text:
+                            visible: false
 
-            # examples of different icons mapped to feature properties
             icons:
                 adult-boutique:
                     filter: { kind: [erotic, adult_boutique] }


### PR DESCRIPTION
Uses `anchor: bottom` and the new zoom interpolated `offset` to properly position label text below their icons/POIs.

This is a bit messy to do because the text and icon are unaware of each other, and while we can set `anchor: bottom` on the text, that only anchors it to the bottom of the actual lat/lng point for the POI, it doesn't account for the actual icon height. Meanwhile,  the icon size itself is changing across zooms! :)

So the current solution was to use an interpolating `offset` that tracks to the size of the icon, so the text is always positioned down an additional half-icon-height. The longer term solution is a unified label style that can do layout for text and icon together.

With correct text placement:

![screen shot 2015-12-10 at 4 10 15 pm](https://cloud.githubusercontent.com/assets/16733/11728590/b180c4ac-9f58-11e5-92e1-8c0107a31299.png)

![screen shot 2015-12-10 at 4 10 46 pm](https://cloud.githubusercontent.com/assets/16733/11728587/ae0435de-9f58-11e5-8bc4-dfa0efed797d.png)

![screen shot 2015-12-10 at 4 12 29 pm](https://cloud.githubusercontent.com/assets/16733/11728629/e643eba6-9f58-11e5-8179-8d96b8018170.png)
