### PR TITLE
Add outline to route line

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -897,6 +897,9 @@ layers:
                 color: '#1183A3'
                 order: 50
                 width: [[0,2.5px],[8,3px],[9,3.5px],[10,4px],[11,5px],[16,8m]]
+                outline:
+                    color: '#253D3D'
+                    width: [[0,.3px],[8,0.3px],[9,.4px],[10,0.5px],[11,0.6px],[16,1m]]
     current_location_gem:
         data: { source: find_me }
         draw:


### PR DESCRIPTION
- color of outline coming from @souperneon 

@sensescape, @nvkelso, you might want to check the width of the outline, I have set it to approx 1/8th of the actual route line width.

This is how it looks in the app:
![screenshot_2016-01-27-15-02-17](https://cloud.githubusercontent.com/assets/360641/12626644/b506bae4-c507-11e5-84d2-7760e9318d1a.png)

![screenshot_2016-01-27-15-04-54](https://cloud.githubusercontent.com/assets/360641/12626653/bc0008a0-c507-11e5-830a-647a96197ce2.png)

![screenshot_2016-01-27-15-04-24](https://cloud.githubusercontent.com/assets/360641/12626659/c2808fd8-c507-11e5-9a5f-87476044ced7.png)
