### PR TITLE
Remove transition to some label icons

### DIFF
--- a/eraser-map.yaml
+++ b/eraser-map.yaml
@@ -929,6 +929,9 @@ layers:
                 size: [36px,46px]
                 collide: false
                 anchor: top
+                transition:
+                    [show, hide]:
+                        time: 0s
     route_stop:
         data: { source: route_stop }
         draw:
@@ -939,6 +942,9 @@ layers:
                 size: [36px,46px]
                 collide: false
                 anchor: top
+                transition:
+                    [show, hide]:
+                        time: 0s
     search:
         data: { source: search }
         draw:
@@ -948,6 +954,9 @@ layers:
                 size: [36px,46px]
                 collide: false
                 anchor: top
+                transition:
+                    [show, hide]:
+                        time: 0s
         inactive:
             filter: { state: inactive }
             draw:
@@ -962,6 +971,9 @@ layers:
                 size: [36px,46px]
                 collide: false
                 anchor: top
+                transition:
+                    [show, hide]:
+                        time: 0s
 
     # Basemap styling
     earth:


### PR DESCRIPTION
Don't apply fading transition to
- search
- reverse_geocode
- route_start
- route_stop

cc @nvkelso 
