### PR TITLE
Update style to Tangram 0.7

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -427,38 +427,18 @@ styles:
         base: lines
         texcoords: true
         shaders:
+            defines:
+                background: vec3(0.867, 0.867, 0.867)
             blocks:
-                global: |
-                    vec2 mirrorTile(vec2 _st, vec2 _zoom){
-                        _st *= _zoom;
-                        if (fract(_st.y * 0.5) > 0.5){
-                            _st.x = _st.x + 0.5;
-                            _st.y = 1.0 - _st.y;
-                        }
-                        return fract(_st);
-                    }
-                    float fillY(vec2 _st, float _pct,float _antia){
-                      return smoothstep( _pct - _antia, _pct, _st.y);
-                    }
-                    float chevron(vec2 st){
-                        st = mirrorTile(st, vec2(1., 6.));
-                        float x = st.x * 2.;
-                        float a = floor(1. + sin(x * 3.14159));
-                        float b = floor(1. - sin(x * 3.14159));
-                        float f = fract(x);
-                        return fillY(st, mix(a, b, f), 0.01);
-                    }
-                    float stripes(vec2 st){
-                        st = st * 10.;
-                        return step(.5, 1.0 - smoothstep(.3, 1., abs(sin(st.y * 3.14159))));
-                    }
-                    float xMargin(vec2 st, float margin){
-                        return 1.0 - clamp(step(margin * .5, st.x) * step(margin * .5, 1.0 - st.x), 0., 1.);
-                    }
-                color: |
-                    vec2 st = v_texcoord;
-                    vec4 foreground = vec4(0.867,0.867,0.867,1.0);
-                    color = mix(v_color, foreground, stripes(st));
+                color: | 
+                    // blend line 50/50 between two colors
+                    float t = fract(v_texcoord.y);
+                    float e = 0.1; // edge feather
+                    vec3 v = vec3(
+                        smoothstep(.0, e, t) * 
+                        (1. - smoothstep(.5, .5 + e, t))
+                    );
+                    color.rgb = mix(color.rgb, background, v);
 
     tools-tilecoords:
         shaders:

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
     <style>
-        body {f
+        body {
             margin: 0px;
             border: 0px;
             padding: 0px;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
     <style>
-        body {
+        body {f
             margin: 0px;
             border: 0px;
             padding: 0px;
@@ -93,7 +93,7 @@
     <script src="lib/keymaster.js"></script>
 
     <!-- Main tangram library -->
-    <script src="https://mapzen.com/tangram/0.6/tangram.min.js"></script>
+    <script src="https://mapzen.com/tangram/0.7/tangram.min.js"></script>
 
     <!-- Demo module -->
     <script src="main.js"></script>


### PR DESCRIPTION
Updates the demo to use Tangram 0.7, and updates the dashed line style for new line UVs.

![tangram-wed apr 13 2016 11-50-38 gmt-0400 edt](https://cloud.githubusercontent.com/assets/16733/14500023/642c27a0-016e-11e6-81d2-ce492df075be.png)

Also see https://github.com/tangrams/zinc-style/pull/2.
