### PR TITLE
Fix tinting on building walls

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -682,32 +682,22 @@ styles:
 
     building-grid:
         base: polygons
-        lighting: vertex
+        lighting: false
         mix: [hsv, scale-buildings]
         texcoords: true
         shaders:
             uniforms:
                 u_tex_grid: building-grid
             defines:
-                WALL_TINT: vec3(1., 3., .800) # modifies roof color HSV
+                WALL_TINT: vec3(1., 3., .800)
             blocks:
-                # applied in vertex shader when using vertex lighting
                 color: |
                     if (dot(vec3(0., 0., 1.), worldNormal()) < 1.0 - TANGRAM_EPSILON) {
                         // If it's a wall
                         color.rgb = hsv2rgb(rgb2hsv(color.rgb) * WALL_TINT);
-                        color.a = 1.0;
-                    } else {
-                        // it's a roof, use vertex color without texture
-                        // using color alpha to differentiate roof/wall
-                        color.a = 0.0;
+                        color.rgb = mix(color.rgb, vec3(0.),
+                                        texture2D(u_tex_grid, v_texcoord).a);
                     }
-                # applied in fragment shader
-                filter: |
-                    // if it's roof then use original color (since color.a == 0)
-                    color.rgb = mix(v_color.rgb, vec3(0.),
-                                    color.a * texture2D(u_tex_grid, v_texcoord).a);
-                    color.a = 1.0;
 
     # building-grid-univ:
     #     mix: building-grid


### PR DESCRIPTION
I found another casualty related to the shader block changes from https://github.com/tangrams/tangram/pull/271 and related PRs (which affected both Tangram JS and ES).

In brief, we stopped executing the `color` shader block in the vertex shader in all cases (partially to enable mixing standard lighting with custom `color` in the fragment shader, such as for procedural patterns).

However, Bubble Wrap was relying on `color` to execute in the vertex shader, to optimize calculations that we know are constant across the surface. These stopped working, causing the buildings to lose their darkened tint on their walls.

These changes were also made in Tangram ES. This behavior is not observed in Eraser Map currently because it's built against an older version of ES, but I verified that the same issue is present in ES master.

This PR fixes the issue by moving the calculations back to the fragment shader. This isn't ideal either since it does the HSV calculations per pixel, when they are only needed per vertex (actually per face!). But it fixes the problem for now. (Caveat, I don't know if the _new_ scene file here works with the _old_ version of ES.)

We could also consider an additional vertex shader block or another configuration, to assist in optimizing cases like this. (It is technically possible to achieve a similar optimization with current behavior by hijacking the `normal` block, but this seems like a bad idea because it makes the same kinds of assumptions about block execution that cause this to break in the first place.)

Expected/fixed:
![tangram-thu may 12 2016 18-46-42 gmt-0400 edt](https://cloud.githubusercontent.com/assets/16733/15232856/fbdd000a-1871-11e6-8aec-1dced2e144c9.png)

Observed/broken:
![tangram-thu may 12 2016 18-47-11 gmt-0400 edt](https://cloud.githubusercontent.com/assets/16733/15232861/fffd9b22-1871-11e6-9b4f-d42bce6645cd.png)
