### PR TITLE
Add mz_dash_line data layer

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -406,6 +406,10 @@ sources:
 #        url: https://gist.githubusercontent.com/anonymous/30c6c1a75c168d91d90c/raw/92bfe55e622766d250b1f2f5d17bdc7c26acb956/map.geojson
 #        # local sf trip
 #        # url: https://gist.githubusercontent.com/anonymous/9a610ebda6fe4be7bccc/raw/8d217e43f2412d48d01534ba115f1e42dac72e68/map.geojson
+#    # Dashed route line
+#    mz_dash_line:
+#        type: GeoJSON
+#        url: https://gist.githubusercontent.com/anonymous/d73b851c64c3e5fbfc2754aa32f44c10/raw/938ae435776e176919c4797bed1465a92e403ef3/map.geojson
 #    # Transit route line
 #    mz_route_line_transit:
 #        type: GeoJSON
@@ -760,15 +764,15 @@ styles:
     text-blend-order:
         base: text
         blend_order: 1
-    ux-dash-line-overlay:
-        base: lines
-        blend: overlay
-        blend_order: 0
-        dash: [2, 1]
     ux-route-line-overlay:
         base: lines
         blend: overlay
         blend_order: 0
+    ux-route-line-dash-overlay:
+        base: lines
+        blend: overlay
+        blend_order: 0
+        dash: [2, 1]
     ux-transit-line-overlay:
         base: lines
         blend: overlay
@@ -813,13 +817,13 @@ layers:
                 color: '#06a6d4'
                 order: 500
                 width: [[0,3.5px],[5,5px],[9,7px],[10,6px],[11,6px],[13,8px],[14,9px],[15,10px],[16,11px],[17,12px],[18,10px]]
-    mz_dash_line:
+    mz_route_line_dash:
         data: { source: mz_dash_line }
         draw:
-            ux-dash-line-overlay:
+            ux-route-line-dash-overlay:
                 color: '#06a6d4'
                 order: 500
-                width: 3px
+                width: [[2,2px],[5,2.5px],[11,3px],[16,7px],[17,9px]]
     mz_route_line_transit:
         data: { source: mz_route_line_transit }
         draw:

--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -760,6 +760,11 @@ styles:
     text-blend-order:
         base: text
         blend_order: 1
+    ux-dash-line-overlay:
+        base: lines
+        blend: overlay
+        blend_order: 0
+        dash: [2, 1]
     ux-route-line-overlay:
         base: lines
         blend: overlay
@@ -808,6 +813,13 @@ layers:
                 color: '#06a6d4'
                 order: 500
                 width: [[0,3.5px],[5,5px],[9,7px],[10,6px],[11,6px],[13,8px],[14,9px],[15,10px],[16,11px],[17,12px],[18,10px]]
+    mz_dash_line:
+        data: { source: mz_dash_line }
+        draw:
+            ux-dash-line-overlay:
+                color: '#06a6d4'
+                order: 500
+                width: 3px
     mz_route_line_transit:
         data: { source: mz_route_line_transit }
         draw:


### PR DESCRIPTION
Adds mz_dash_line layer for use in the multi-modal route preview. If we like this, I'll update cinnabar and refill too.

![screenshot_20160725-154519](https://cloud.githubusercontent.com/assets/494323/17118706/12788eb4-527f-11e6-9b1c-353416a3596c.png)

![screenshot_20160725-154435](https://cloud.githubusercontent.com/assets/494323/17118711/18fe8428-527f-11e6-9ec0-a4275938a5ed.png)

cc/ @souperneon how do you feel about these lines? 
