### PR TITLE
Fix precision issues in building shader in some contexts

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -852,7 +852,7 @@ styles:
                 WALL_TINT: vec3(1., 3., .800)
             blocks:
                 color: |
-                    if (dot(vec3(0., 0., 1.), worldNormal()) < 1.0 - TANGRAM_EPSILON) {
+                    if (dot(vec3(0., 0., 1.), worldNormal()) < .5) {
                         // If it's a wall
                         color.rgb = hsv2rgb(rgb2hsv(color.rgb) * WALL_TINT);
                         color.rgb = mix(color.rgb, vec3(0.),


### PR DESCRIPTION
Re: https://github.com/mapzen/eraser-map/issues/722

In theory this edit should not change the shader output, but in some contexts there appear to be some liberties taken with floating point arithmetic ;)

This resolves the issue above in tangram-js on Edge and may resolve the issue in tangram-es on Sailfish OS (I can't test that one myself).
