### PR TITLE
Use a 'global' to set building extrusion visibility

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -363,6 +363,9 @@ global:
     building_o:  5                          # building stroke order
     building_e: true                        # building stroke order
 
+    # building extrusion
+    building_extrude_on: true
+
 
 textures:
     pois:
@@ -2692,7 +2695,6 @@ layers:
         # building footprints, pre-extrusion
         footprints:
             filter:
-                $zoom: { max: 18 }
                 any:
                     # show footprints for buildings at least one zoom level before they will be extruded
                     - { $zoom: [13], area: { min: 50000 } }
@@ -2715,6 +2717,7 @@ layers:
 
         # 3d buildings
         extrude:
+            visible: global.building_extrude_on
             filter:
                 any:
                     - { $zoom: [15], height: { min: 190 } }
@@ -2728,13 +2731,11 @@ layers:
                     - { $zoom: { min: 18 }, area: true }
             draw:
                 polygons:
-                    visible: true
                     order: 438
                     style: building-grid
                     extrude: function() { return feature.height || 20; }
                     color: [0.892,0.880,0.878]
                 lines:
-                    visible: true
                     order: 439
                     style: building-lines
                     extrude: function() { return feature.height || 20; }


### PR DESCRIPTION
Resolves #198 

Originally I wanted to use a global for the `extrude` property. That works fine when a client application only wants to turn extrusion to `false`, but then to restore the original behavior the client code would need to know the function that was previously used for extrusion. Since we draw building footprints in a separate layer anyway, it's easier just to set the visibility of the layer called "extrude". 
