### PR TITLE
Transit additions to bubble-wrap.yaml

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -6905,7 +6905,8 @@ layers:
                     icons:
                         #visible: false
                         size: [[12, 8px], [14, 6px], [15, 16px]]
-                    text-blend-order: { visible: false }
+                        text:
+                            visible: false
             low-priority-early-z14:
                 filter: { kind_tile_rank: { min: 7 }, $zoom: [14] }
                 draw:
@@ -6934,7 +6935,7 @@ layers:
             draw:
                 icons:
                     size: [[15, 8px], [16, 18px]]
-                    visible: true
+                    visible: global.sdk_transit_overlay
                     sprite: light-rail
                     text:
                         visible: false
@@ -6943,7 +6944,7 @@ layers:
             draw:
                 icons:
                     size: [[15, 8px], [16, 18px]]
-                    visible: true
+                    visible: global.sdk_transit_overlay
                     sprite: generic
                     text:
                         visible: false
@@ -6952,7 +6953,7 @@ layers:
             draw:
                 icons:
                     size: [[13, 0px], [14, 7px], [15, 8px]]
-                    visible: true
+                    visible: global.sdk_transit_overlay
                     sprite: light-rail
                     text:
                         visible: false

--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -148,6 +148,11 @@ global:
     sdk_order_under_everything_8: 8
     sdk_order_under_everything_9: 9
     #
+    # TRANSIT OVERLAY
+    # should default to "auto", with SDK overriding it to true or false,
+    # or app logic sets other booleans that triggers auto behavior later
+    sdk_transit_overlay: false
+    #
     # default order for basemap features
     feature_order: function() { return feature.sort_key; }
     #
@@ -6685,6 +6690,400 @@ layers:
                 order: global.feature_order
                 color: [[4,[0.965,0.600,0.882]],[6,[0.965,0.600,0.882]],[7,[0.882,0.639,0.827]],[8,[0.757,0.729,0.753]]]
 
+    transit-rail-lines:
+        data: { source: mapzen, layer: transit }
+        filter:
+            not: { kind: [platform, railway] }
+        draw:
+            lines:
+                order: 499
+                visible: global.sdk_transit_overlay
+                color: purple
+                width: [[5,1.5px],[6,2px],[11,3px],[18,4px]]
+                interactive: true
+                outline:
+                    color: [1.,1.,1.,.8]
+                    width: [[7,0px],[8,0.25px],[9,0.5px],[12,1.0px],[13,1.75px],[14,2px]]
+                    #width: [[12,1.0px],[13,1.75px],[14,2px]]
+        train-sizing-color:
+            filter: { kind: train }
+            draw:
+                lines:
+                    color: purple
+                    width: [[5,1.0px],[6,1.0px],[7,1.25px],[11,2.0px],[13,2.5px],[18,3.5px]]
+                    outline:
+                        width: [[12,1.0px],[13,1.75px],[14,2px]]
+            stack-below-other-transit-later-zooms:
+                filter: { $zoom: { min: 9 } }
+                draw:
+                    lines:
+                        order: 511
+        subway-sizing:
+            filter: { kind: subway }
+            draw:
+                lines:
+                    width: [[9,1px],[11,2px],[12,3px],[13,4px],[15,5px],[16,7px],[17,9px]]
+                    outline:
+                        #color: [[10,white],[11,black]]
+                        width: [[9,0px],[10,0.5px],[12,1.25px],[13,1.5px],[15,2px]]
+                        #width: [[12,1.5px],[13,2.0px],[14,2.5px]]
+        light-rail-and-tram-sizing:
+            filter: { kind: [light_rail, tram] }
+            draw:
+                lines:
+                    width: [[10,1px],[12,1.5px],[15,2px],[18,3.5px]]
+                    outline:
+                        #color: [[11,white],[12,black]]
+                        width: [[12,0.25px],[13,0.5px],[14,1px],[16,2px]]
+        has-data-color:
+            filter: { colour: true }
+            draw:
+                lines:
+                    order: 510
+                    width: [[9,2px],[11,3px],[12,4px]]
+                    color: function() { return feature.colour || 'purple'; }
+                    #outline:
+                        #color: function() { if(feature.colour == 'silver') { return 'black'; } else { return [0.,0.,0.,.1]; } }
+                        #width: [[12,1.0px],[13,1.75px],[14,2px]]
+            train-with-color:
+                filter: { kind: train }
+                draw:
+                    lines:
+                        order: 514
+            subway-with-color:
+                filter: { kind: subway }
+                draw:
+                    lines:
+                        order: 513
+            light-rail-and-tram-with-color:
+                filter: { kind: [light_rail, tram] }
+                draw:
+                    lines:
+                        order: 512
+        missing-colour:
+            filter: { colour: false }
+            train-missing-color:
+                filter: { kind: train, colour: false }
+                draw:
+                    lines:
+                        #width: [[5,1.25px],[6,1.75px],[11,2.0px],[13,2.5px],[18,2.5m]]
+                        order: 506
+            subway-missing-color:
+                filter: { kind: subway, colour: false }
+                draw:
+                    lines:
+                        order: 505
+                        #outline:
+#                            width: [[12,1.5px],[13,2.0px],[14,2.5px]]
+            light-rail-and-tram-missing-color:
+                filter: { kind: [light_rail, tram], colour: false }
+                draw:
+                    lines:
+                        order: 504
+        labels-transit-lines-early:
+            filter: { $zoom: [13,14], ref: true }
+            draw:
+                text:
+                    visible: global.sdk_transit_overlay
+                    priority: 20
+                    text_source: function() { if( feature.ref.length < 4 ) { return feature.ref; } else { return ''; } }
+                    font:
+                        fill: black
+                        size: 12px
+                        weight: bold
+                        stroke: { color: white, width: 2 }
+        labels-transit-lines:
+            filter: { $zoom: { min: 15 } }
+            draw:
+                text:
+                    visible: global.sdk_transit_overlay
+                    priority: 20
+                    text_source: ref
+                    font:
+                        fill: black
+                        size: 14px
+                        weight: bold
+                        stroke: { color: white, width: 2 }
+            z19-show-long-route-name:
+                filter: { $zoom: { min: 19 } }
+                draw:
+                    text:
+                        text_source: function() { return feature.route_name || feature.ref; }
+                        font:
+                            stroke: { color: white, width: 3px }
+
+#    transit-bus-roads:
+#        data: { source: mapzen, layer: roads }
+#        filter: { is_bus_route: true }
+#        draw:
+#            lines:
+#                visible: global.sdk_transit_overlay
+#                interactive: false
+#                color: [[13,[0,0,1,0.5]],[15,blue]]
+#                width: [[11,0.5px],[12,0.8px],[16,1.25px],[18,1m]]
+#                # let roads sort themselves past zoom 14
+#                order: 488
+#                # but give them all the same outline
+#                outline:
+#                    order: 487
+
+    transit-station-labels:
+        data: { source: mapzen, layer: [pois,landuse] }
+        filter:
+            kind: [station, tram_stop, bus_station, subway_entrance, halt, stop, platform, bus_stop, stop_position ]
+            any:
+                - area: false
+                  all:
+                - area: true
+                  all:
+                      - $geometry: point
+                      - kind: true
+        draw:
+            icons:
+                visible: global.sdk_transit_overlay
+                size: [[13, 12px], [16, 16px], [19, 20px]]
+                interactive: true
+                priority: 15
+                text:
+                    buffer: 4px
+                    move_into_tile: false # preserves text alignment w/icons in JS
+                    #anchor: bottom
+                    #offset: [[13, [0, 6px]], [16, [0, 8px]], [19, [0, 10px]]] # offset tracks alongside icon size (half icon height)
+                    interactive: true
+                    priority: 16
+                    font:
+                        weight: 500
+                        fill: black
+                        weight: 400
+                        size: 11px
+                        stroke: { color: white, width: 3 }
+        poi_labels-z14:
+            filter: { $zoom: [14] }
+            draw: { icons: { text: { font: { size: 11px } } } }
+        poi_labels-z15:
+            filter: { $zoom: [15,16,17] }
+            draw: { icons: { text: { font: { size: 12px, stroke: { width: 2 } } } } }
+        poi_labels-z18:
+            filter: { $zoom: [18,19] }
+            draw: { icons: { text: { font: { size: 12px, weight: 600, stroke: { width: 3 } } } } }
+        poi_labels-z20-up:
+            filter: { $zoom: { min: 20 } }
+            draw: { icons: { text: { font: { size: 14px, weight: 600, stroke: { width: 3 }  } } } }
+        station-train-subway:
+            filter: { kind: [station, train-station, train_station] } #, $zoom: { min: 13 }
+            draw:
+                icons:
+                    sprite: train-station
+                    size: [[13, 12px], [14, 14px], [15, 16px], [17, 20px]]
+                    priority: 11
+                    text:
+                        #offset: [[13, [0, 6px]], [14, [0, 7px]],[15, [0, 8px]], [17, [0, 10px]]]
+                        priority: 12
+            low-priority-early:
+                filter: { kind_tile_rank: { min: 3 }, $zoom: { min: 0, max: 12 } }
+                draw:
+                    icons:
+                        size: [[12, 5px], [14, 6px], [15, 16px]]
+                        text:
+                            visible: false
+                long-tail:
+                    filter: { kind_tile_rank: { min: 10 }, $zoom: [10] }
+                    draw:
+                        icons:
+                            visible: false
+            low-priority-early-z12:
+                filter: { kind_tile_rank: { min: 8 }, $zoom: [12] }
+                draw:
+                    icons:
+#                        visible: false
+                        size: [[12, 5px], [14, 6px], [15, 16px]]
+                        text:
+                            visible: false
+            low-priority-early-z13:
+                filter: { kind_tile_rank: { min: 8 }, $zoom: [13] }
+                draw:
+                    icons:
+                        #visible: false
+                        size: [[12, 8px], [14, 6px], [15, 16px]]
+                    text-blend-order: { visible: false }
+            low-priority-early-z14:
+                filter: { kind_tile_rank: { min: 7 }, $zoom: [14] }
+                draw:
+                    icons:
+                        size: [[12, 10px], [14, 11px], [15, 16px]]
+                        #visible: false
+                        text:
+                            visible: false
+            late:
+                filter: { $zoom: { min: 16 } }
+                draw:
+                    icons:
+                        text:
+                            font:
+                                weight: 600
+                                size: 12px
+        subway-early:
+            filter: { is_subway: true, is_train: false, $zoom: { max: 12 } }
+            draw:
+                icons:
+                    visible: false
+                    text:
+                        visible: false
+        halt-early:
+            filter: { kind: [halt,stop], $zoom: { max: 15 } }
+            draw:
+                icons:
+                    size: [[15, 8px], [16, 18px]]
+                    visible: true
+                    sprite: light-rail
+                    text:
+                        visible: false
+        platform-early:
+            filter: { kind: [platform] }
+            draw:
+                icons:
+                    size: [[15, 8px], [16, 18px]]
+                    visible: true
+                    sprite: generic
+                    text:
+                        visible: false
+        tram-stop-early:
+            filter: { kind: [tram_stop], $zoom: { max: 16 } }
+            draw:
+                icons:
+                    size: [[13, 0px], [14, 7px], [15, 8px]]
+                    visible: true
+                    sprite: light-rail
+                    text:
+                        visible: false
+        tram-stop:
+            filter: { kind: tram_stop, $zoom: { min: 16 } }
+            draw:
+                icons:
+                    size: [[16, 12px], [17, 14px], [18, 18px]]
+                    sprite: light-rail
+                    text:
+                        #offset: [[13, [0, 6px]], [16, [0, 9px]]]
+        bus-like-labels:
+            filter:
+                kind: [platform, stop_position]
+            draw:
+                icons:
+                    size: [[13, 8px], [16, 10px], [17, 12px], [18, 18px]]
+                    sprite: bus-station
+                    text:
+                        interactive: true
+                        font:
+                            fill: black
+                            size: 12px
+                            stroke: { color: white, width: 4 }
+        bus-station-labels:
+            filter:
+                kind: [bus_station, bus_stop]
+                $zoom: { min: 16 }
+            draw:
+                icons:
+                    size: [[13, 12px], [16, 18px]]
+                    sprite: bus-station
+                    priority: 17
+                    text:
+                        interactive: true
+                        priority: 18
+                        font:
+                            fill: black
+                            size: 12px
+                            stroke: { color: white, width: 4 }
+            bus_stop:
+                filter:
+                    kind: [bus_stop]
+                    $zoom: { max: 19 }
+                draw:
+                    icons:
+                        size: [[13, 8px], [19, 18px]]
+                        text:
+                            visible: false
+        subway-entrance:
+            filter:
+                kind: [subway_entrance]
+            draw:
+                icons:
+                    sprite: subway-entrance
+                    size: [[17, 12px], [19, 14px]]
+                    priority: 19
+                    text:
+                        #offset: [[17, [0, 6px]], [19, [0, 7px]]] # offset tracks alongside icon size (half icon height)
+                        priority: 20
+                        interactive: true
+                        text_source: function() { if( feature.ref || feature.name ) { if( feature.ref && feature.name ) { return '[' + feature.ref + ']\n' + feature.name; } else { return feature.name; } } else { return "Entrance"; } }
+                        font:
+                            fill: black
+                            size: 12px
+                            stroke: { color: white, width: 4 }
+
+    transit-station-buildings:
+        data: { source: mapzen, layer: [buildings] }
+        filter:
+            any:
+                - landuse_kind: [station]
+        draw:
+            polygons:
+                visible: global.sdk_transit_overlay
+                color: '#bdadbf'
+                order: 500
+                #extrude: function() { return feature.height || 20; }
+            outline:
+                visible: global.sdk_transit_overlay
+                style: lines
+                order: 501
+                color: '#d534df'
+                width: [[14,0.1px],[15,0.5px],[17,0.5px],[18,0.75px],[19,0.25m]]
+                #extrude: function() { return feature.height || 20; }
+
+#    transit-platforms:
+#        data: { source: mapzen, layer: transit }
+#        filter: { kind: platform, $zoom: { min: 15 }, $geometry: [polygon,line] }
+#        draw:
+#            lines:
+#                visible: global.sdk_transit_overlay
+#                color: '#bc8f96'
+#                width: 10m          # something fishy here with the #include syntax in v0.7 tangram?
+#                order: 1000         # this selection should sort above basemap, but grey Zinc color still applies
+#                outline:
+#                    order: 1002
+#            polygons:
+#                visible: global.sdk_transit_overlay
+#                order: 1001
+#        polygon_geom:
+#            filter: { $geometry: polygon }
+#            draw:
+#                polygons:
+#                    color: '#bc8f96'
+#                    outline:
+#                        color: '#bc8f96'
+#                        width: [[15,0px],[16,0.5px],[17,1px],[19,2px]]
+#                lines:
+#                    visible: false
+
+    transit-basemap-railway-late:
+        data: { source: mapzen, layer: roads }
+        filter: { kind: rail, $zoom: { min: 16 }, not: { railway: [subway,light_rail,tram] } }
+        draw:
+            lines:
+                visible: global.sdk_transit_overlay
+                interactive: true
+                color: black
+                width: [[15,0.5px],[16,0.75px],[18,1m]]
+                # let roads sort themselves past zoom 14
+                order: 491
+                # but give them all the same outline
+                outline:
+                    order: 490
+        service:
+            filter: { service: true }
+            draw:
+                lines:
+                    color: black
+                    width: [[14,0px],[15,0.4px],[16,0.6px],[18,0.7m]]
 
     debug:
         data: { source: mapzen }

--- a/main.js
+++ b/main.js
@@ -227,7 +227,20 @@ map = (function () {
             scene.updateConfig();
             //window.location.search = 'language=' + value;
         });
-
+//
+//         // Transit selector
+//         var transit_overlay = {
+//             '(default)': false,
+//             'Show': true,
+//             'Hide': false
+//         };
+//         // use transit ux, else default to false
+//         gui.transit_overlay = query.transit_overlay || false;
+//         gui.add(gui, 'transit_overlay', transit_overlay).onChange(function(value) {
+//             scene.config.global.sdk_transit_overlay = value;
+//             scene.updateConfig();
+//         });
+//
         // Take a screenshot and save to file
         gui.save_screenshot = function () {
             return scene.screenshot().then(function(screenshot) {


### PR DESCRIPTION
- Grabbed all @nvkelso changes from https://github.com/tangrams/bubble-wrap/pull/202 and put it in main bubble-wrap.yaml.
- Also adds sdk_transit_overlay global
