### PR TITLE
Use map background color instead of earth layer

### DIFF
--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -288,7 +288,6 @@ global:
     fence: [0.827,0.808,0.780]
     #
     #landuse
-    scene1: '#eee'                          # map background, water
     water1: [0.83, 0.83, 0.83]              # water
     water2: [.75,.75,.75]                   # playa
     water1_o: '#9dc3de'                     # water stroke
@@ -959,7 +958,7 @@ styles:
 
 scene:
     background:
-        color: global.scene1
+        color: [0.870,0.870,0.870]
 
 layers:
     # Map overlays for styling the server response (using special source layer names) for route line, current location, and search result pins
@@ -1108,13 +1107,6 @@ layers:
                 width: 0px
 
     # Basemap styling
-    earth:
-        data: { source: mapzen, layer: earth }
-        draw:
-            polygons:
-                order: global.feature_order
-                color: [0.870,0.870,0.870]
-
     water:
         data: { source: mapzen, layer: water }
         draw:

--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -292,7 +292,7 @@ global:
     water2: [.75,.75,.75]                   # playa
     water1_o: '#9dc3de'                     # water stroke
     water2_o: '#9dc3de'                     # water stroke 2
-    earth1: [0.870,0.870,0.870]             # land color
+    earth1: [0.870,0.870,0.870]             # land color, used to set scene background color
     earth1_r: '#666'                        # land color road
     earth2: '#e9e4e0'                       # urban
     earth2_v: false                         # urban

--- a/bubble-wrap.yaml
+++ b/bubble-wrap.yaml
@@ -292,7 +292,7 @@ global:
     water2: [.75,.75,.75]                   # playa
     water1_o: '#9dc3de'                     # water stroke
     water2_o: '#9dc3de'                     # water stroke 2
-    earth1: '#666'                          # land color
+    earth1: [0.870,0.870,0.870]             # land color
     earth1_r: '#666'                        # land color road
     earth2: '#e9e4e0'                       # urban
     earth2_v: false                         # urban
@@ -958,7 +958,7 @@ styles:
 
 scene:
     background:
-        color: [0.870,0.870,0.870]
+        color: global.earth1
 
 layers:
     # Map overlays for styling the server response (using special source layer names) for route line, current location, and search result pins


### PR DESCRIPTION
For this style (and some other house styles), we don't need to draw an `earth` layer at all, we can just use the map background color. This reduces a lot of pixel fill volume, which can be a bottleneck for us.

I found an improvement of up to 5fps depending on scene complexity (and this was on non-retina, we should also test displays with higher pixel volume).

Differ tests confirm there's not difference at all in rendering output:
http://tangrams.github.io/differ/?1=https://tangrams.github.io/bubble-wrap/bubble-wrap.yaml&2=https://raw.githubusercontent.com/tangrams/bubble-wrap/background-color/bubble-wrap.yaml&lib1=0.10&lib2=0.10&ignore1&ignore2&go
