### PR TITLE
building-lines style doesn't need texture coordinates

### DIFF
--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -1038,7 +1038,6 @@ styles:
     building-lines:
         base: lines
         mix: scale-buildings
-        texcoords: true
     lines_transparent:
         base: lines
         blend: overlay


### PR DESCRIPTION
The `building-lines` style has texture coordinates enabled (`texcoords: true`), but the style does not use them. Removing them saves some memory.