### PR TITLE
Add interactive to other mz layers

### DIFF
--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -1134,6 +1134,7 @@ layers:
         data: { source: mz_current_location }
         draw:
             ux-location-gem-overlay:
+                interactive: global.sdk_interactive
                 sprite: ux-current-location
                 size: 36px
                 collide: false
@@ -1195,6 +1196,7 @@ layers:
         data: { source: mz_dropped_pin }
         draw:
             ux-icons-overlay:
+                interactive: global.sdk_interactive
                 sprite: ux-search-active
                 size: [36px,54px]
                 collide: false
@@ -1323,6 +1325,7 @@ layers:
         data: { source: mz_default_line }
         draw:
             sdk-line-overlay:
+                interactive: global.sdk_interactive
                 color: '#06a6d4'
                 order: 503
                 width: 3px
@@ -1330,6 +1333,7 @@ layers:
         data: { source: mz_default_polygon }
         draw:
             sdk-polygon-overlay:
+                interactive: global.sdk_interactive
                 color: [0.02,0.65,0.82,0.5]  #'#06b1e2'
                 order: 501
             sdk-line-overlay:


### PR DESCRIPTION
Added interactive for the following mz sdk layers:
- `mz_current_location_gem`,
- `mz_dropped_pin`,
- `mz_default_line`
- `mz_default_polygon`

While updating the mapzen android sdk to use latest tangram-es release, @sarahlensing and I found that we need to have interactivity set for custom MapData. We already had this for `point` data layers, but will also make sense for `polygon` and `polyline` data layers. Along with that I think it does make sense to have interactivity set for `mz_current_location_gem`.

Along with this it might make sense to have `interactive` set for `mz_route_line`, `mz_route_line_dash`, `mz_route_line_transit` to provide functionality of user picking one of multiple routes. (This has a dependency currently on valhalla functionality, I think we do not have valhalla functionality to get multiple routes). Also maybe have it set for `mz_route_transit_stop`, again dependent on valhalla functionality. I have not made any changes for this in this PR.

@nvkelso I am not sure how you propagate these to different variants of a style sheet. Let me know if its manual, then will update other bubble-wrap variant yaml files. Will also file a PR for other house styles once we have a consensus here.

With respect to using this in the upcoming version of android and ios sdk, me and @sarahlensing were thinking if we can have a patched release of 7.0.1 with these changes. @nvkelso thoughts on this?