### PR TITLE
refactor pattern-dots

### DIFF
--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -629,21 +629,19 @@ styles:
                 global: |
                     #ifdef TANGRAM_FRAGMENT_SHADER
                         float TileDots(float scale, float size) {
+
+                            // controls
+                            float DOT_SIZE = 1.8; // bigger value = smaller dots
+                            float SPEED = 10.; // bigger value = faster transition
+
                             vec2 tc = TileCoords() * scale * pow(2., floor(u_map_position.z) - abs(u_tile_origin.z));
                             vec2 IN = brick(tc, 2.);
-                            float A = circleDF(vec2(0.5) - IN) * 1.8;
-                            float d = 0.0;
-                            if (u_map_position.z < 18.) {
-                                vec2 OUT = fract(tc * 2.);
-                                float B = circleDF(vec2(0.25) - OUT) * 7.;
-                                B = min(B, circleDF(vec2(0.75, 0.25) - OUT) * 7.);
-                                B = min(B, circleDF(vec2(0.50, 0.75) - OUT) * 7.);
-                                B = min(B, circleDF(vec2(0.00, 0.75) - OUT) * 7.);
-                                B = min(B, circleDF(vec2(1.00, 0.75) - OUT) * 7.);
-                                d = mix(A, B, pow(fract(u_map_position.z), 10.));
-                            } else {
-                                d = A;
-                            }
+                            float A = circleDF(vec2(0.5) - IN) * DOT_SIZE;
+                            vec2 OUT = brick(tc, 4.);
+                            float B = circleDF(vec2(0.5) - OUT) * DOT_SIZE;
+                            // keep B dots big as they fade in, to maintain density
+                            B *= pow(fract(u_map_position.z), SPEED);
+                            float d = mix(A, B, pow(fract(u_map_position.z), SPEED));
                             return aastep(size, d);
                         }
                     #endif

--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -634,14 +634,15 @@ styles:
                             float DOT_SIZE = 1.8; // bigger value = smaller dots
                             float SPEED = 10.; // bigger value = faster transition
 
-                            vec2 tc = TileCoords() * scale * pow(2., floor(u_map_position.z) - abs(u_tile_origin.z));
+                            vec2 tc = TileCoords() * scale * exp2(floor(u_map_position.z) - abs(u_tile_origin.z));
                             vec2 IN = brick(tc, 2.);
                             float A = circleDF(vec2(0.5) - IN) * DOT_SIZE;
                             vec2 OUT = brick(tc, 4.);
                             float B = circleDF(vec2(0.5) - OUT) * DOT_SIZE;
+                            float transition = pow(fract(u_map_position.z), SPEED);
                             // keep B dots big as they fade in, to maintain density
-                            B *= pow(fract(u_map_position.z), SPEED);
-                            float d = mix(A, B, pow(fract(u_map_position.z), SPEED));
+                            B *= transition;
+                            float d = mix(A, B, transition);
                             return aastep(size, d);
                         }
                     #endif


### PR DESCRIPTION
This updates the `pattern-dots` style with a refactored transition between zoom levels. In both versions, the transition "splits" a dot into three other dots which take their place in a "brick" pattern. In the old style, the new split dots shrink briefly before enlarging as they take their final position:

![olddots](https://user-images.githubusercontent.com/459970/32865928-23cd7120-ca1a-11e7-9c42-ffa44ac2f086.gif)

This caused a momentary lightening of the fill when crossing integer zoom levels, as the density of the pattern dips briefly. View this effect by zooming in and out here: https://mapzen.com/tangram/view/?api=5/1227#13.6333/45.2459/-114.7776

I've simplified the function while (afaik) not removing any functionality, added a couple of comments, made some parameters more clear, and kept the new "split" dots from shrinking, which maintains pattern density better across zoom levels:

![newdots](https://user-images.githubusercontent.com/459970/32865931-2680a70c-ca1a-11e7-93a6-b07aa545387c.gif)

View it in action here: https://mapzen.com/tangram/view/?api=5/1228#15.2625/45.2478/-114.7737