### PR TITLE
fix point offset units

### DIFF
--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -3920,7 +3920,7 @@ layers:
                     draw:
                         text-blend-order:
                             text_source: global.ux_language_text_source_boundary_lines
-                            offset: 0px
+                            offset: [0px, 0px]
         other_country_boundary_disputed_etc:
             filter: { kind: [disputed, indefinite, indeterminate, lease_limit, line_of_control, overlay_limit] }
             draw:
@@ -3978,7 +3978,7 @@ layers:
                     draw:
                         text-blend-order:
                             text_source: global.ux_language_text_source_boundary_lines
-                            offset: 0px
+                            offset: [0px, 0px]
 
     places:
         data: { source: mapzen, layer: places }

--- a/bubble-wrap-style.yaml
+++ b/bubble-wrap-style.yaml
@@ -3906,7 +3906,7 @@ layers:
                         priority: 2
                         visible: global.text_visible_admin
                         text_source: global.ux_language_text_source_boundary_lines_left_right
-                        offset: [0, 5px]
+                        offset: [0px, 5px]
                         text_wrap: 100px
                         font:
                             family: Varela
@@ -3964,7 +3964,7 @@ layers:
                         priority: 3
                         visible: global.text_visible_admin
                         text_source: global.ux_language_text_source_boundary_lines_left_right
-                        offset: [0, 5px]
+                        offset: [0px, 5px]
                         text_wrap: 100px
                         font:
                             family: Varela


### PR DESCRIPTION
Refer documentation here: https://github.com/tangrams/tangram-docs/blob/gh-pages/pages/draw.md#offset-points-text

I also tested this on tangram.city/play:

<img width="1094" alt="screen shot 2018-04-23 at 6 02 35 pm" src="https://user-images.githubusercontent.com/360641/39200336-c30994d6-47a0-11e8-88ba-fcbd91346810.png">

<img width="873" alt="screen shot 2018-04-23 at 6 02 23 pm" src="https://user-images.githubusercontent.com/360641/39200344-c6d6d81c-47a0-11e8-9c90-bcb6c72b95c9.png">

<img width="1005" alt="screen shot 2018-04-23 at 6 02 16 pm" src="https://user-images.githubusercontent.com/360641/39200355-cdf8658e-47a0-11e8-80da-b554c74b99ed.png">
